### PR TITLE
Added capability name

### DIFF
--- a/.schema/config.0.1.json
+++ b/.schema/config.0.1.json
@@ -121,26 +121,16 @@
         },
         "environment": {
           "type": "object",
-          "properties": {
-            "framework": {
-              "type": "string",
-              "description": ""
-            },
-            "environment": {
-              "type": "object",
-              "patternProperties": {
-                "^[A-Za-z0-9_]+$": { "type": "string" }
-              }
-            },
-            "capabilities": {
-              "oneOf": [
-                { "$ref":  "#/definitions/capabilities" },
-                { "$ref":  "#/definitions/capabilitiesArray" }
-              ]
-            }
+          "patternProperties": {
+            "^[A-Za-z0-9_]+$": { "type": "string" }
           }
         },
-        "capabilities": { "$ref":  "#/definitions/capabilities" }
+        "capabilities": {
+          "oneOf": [
+            { "$ref":  "#/definitions/capabilities" },
+            { "$ref":  "#/definitions/capabilitiesArray" }
+          ]
+        }
       },
       "patternProperties": {"^x-": {}},
       "additionalProperties": false

--- a/.schema/config.0.1.json
+++ b/.schema/config.0.1.json
@@ -121,8 +121,23 @@
         },
         "environment": {
           "type": "object",
-          "patternProperties": {
-            "^[A-Za-z0-9_]+$": { "type": "string" }
+          "properties": {
+            "framework": {
+              "type": "string",
+              "description": ""
+            },
+            "environment": {
+              "type": "object",
+              "patternProperties": {
+                "^[A-Za-z0-9_]+$": { "type": "string" }
+              }
+            },
+            "capabilities": {
+              "oneOf": [
+                { "$ref":  "#/definitions/capabilities" },
+                { "$ref":  "#/definitions/capabilitiesArray" }
+              ]
+            }
           }
         },
         "capabilities": { "$ref":  "#/definitions/capabilities" }
@@ -204,13 +219,28 @@
       "additionalProperties": false
     },
     "capabilities": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/capability" }
+    },
+    "capabilitiesArray": {
       "type": "array",
-      "items": { "$ref": "#/definitions/capability" }
+      "items": { "$ref": "#/definitions/namedCapability" }
     },
     "capability": {
       "type": "object",
       "properties": {
         "namespace": { "types": "string" },
+        "module": { "type": "string" },
+        "module_version": { "type": "string" },
+        "vars": { "$ref": "#/definitions/variables" },
+        "connections": { "$ref": "#/definitions/connection_targets" }
+      }
+    },
+    "namedCapability": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "module": { "type": "string" },
         "module_version": { "type": "string" },
         "vars": { "$ref": "#/definitions/variables" },

--- a/config/app_configuration.go
+++ b/config/app_configuration.go
@@ -28,6 +28,7 @@ func convertCapabilities(parsed yaml.CapabilityConfigurations) CapabilityConfigu
 			moduleVersion = *capValue.ModuleSourceVersion
 		}
 		result[i] = &CapabilityConfiguration{
+			Name:                capValue.Name,
 			ModuleSource:        capValue.ModuleSource,
 			ModuleSourceVersion: moduleVersion,
 			Variables:           convertVariables(capValue.Variables),

--- a/config/app_configuration.go
+++ b/config/app_configuration.go
@@ -106,7 +106,7 @@ func (a *AppConfiguration) Normalize(ctx context.Context, pc core.ObjectPathCont
 func (a *AppConfiguration) ToBlock(orgName string, stackId int64) types.Block {
 	block := a.BlockConfiguration.ToBlock(orgName, stackId)
 	block.Framework = a.Framework
-	block.Capabilities = a.Capabilities.ToCapabilities(stackId)
+	block.Capabilities = a.Capabilities.ToCapabilities()
 	return block
 }
 

--- a/config/block_configuration.go
+++ b/config/block_configuration.go
@@ -158,12 +158,6 @@ func (b *BlockConfiguration) ToBlock(orgName string, stackId int64) types.Block 
 		ModuleSourceVersion: b.ModuleSourceVersion,
 		Connections:         b.Connections.Targets(),
 	}
-	for k, conn := range block.Connections {
-		if conn.StackId == 0 && conn.StackName == "" {
-			conn.StackId = stackId
-		}
-		block.Connections[k] = conn
-	}
 	return block
 }
 

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -49,24 +49,17 @@ func (c CapabilityConfigurations) Validate(ic core.IacContext, pc core.ObjectPat
 	return nil
 }
 
-func (c CapabilityConfigurations) ToCapabilities(stackId int64) []types.Capability {
+func (c CapabilityConfigurations) ToCapabilities() []types.Capability {
 	var result []types.Capability
 	for _, cur := range c {
 		capability := types.Capability{
 			Name:                cur.Name,
 			ModuleSource:        cur.ModuleSource,
 			ModuleSourceVersion: cur.ModuleSourceVersion,
-			Connections:         types.ConnectionTargets{},
+			Connections:         cur.Connections.Targets(),
 		}
 		if cur.Namespace != nil {
 			capability.Namespace = *cur.Namespace
-		}
-		for key, conn := range cur.Connections {
-			target := conn.Target
-			if target.StackId == 0 && target.StackName == "" {
-				target.StackId = stackId
-			}
-			capability.Connections[key] = target
 		}
 		result = append(result, capability)
 	}

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -53,6 +53,7 @@ func (c CapabilityConfigurations) ToCapabilities(stackId int64) []types.Capabili
 	var result []types.Capability
 	for _, cur := range c {
 		capability := types.Capability{
+			Name:                cur.Name,
 			ModuleSource:        cur.ModuleSource,
 			ModuleSourceVersion: cur.ModuleSourceVersion,
 			Connections:         types.ConnectionTargets{},

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -108,6 +108,7 @@ func (c CapabilityConfigurations) Resolve(ctx context.Context, resolver core.Res
 }
 
 type CapabilityConfiguration struct {
+	Name                string                   `json:"name"`
 	ModuleSource        string                   `json:"moduleSource"`
 	ModuleSourceVersion string                   `json:"moduleSourceVersion"`
 	Variables           VariableConfigurations   `json:"vars"`
@@ -120,6 +121,7 @@ type CapabilityConfiguration struct {
 
 func (c *CapabilityConfiguration) Identity() core.CapabilityIdentity {
 	return core.CapabilityIdentity{
+		Name:              c.Name,
 		ModuleSource:      c.ModuleSource,
 		ConnectionTargets: c.Connections.Targets(),
 	}

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -166,16 +166,22 @@ func (c *CapabilityConfiguration) Resolve(ctx context.Context, resolver core.Res
 }
 
 func (c *CapabilityConfiguration) Validate(ic core.IacContext, pc core.ObjectPathContext, appModule *types.Module) core.ValidateErrors {
+	errs := core.ValidateErrors{}
+	// TODO: After deprecating (ModuleSource+ConnectionTargets), validate Name
+	//if c.Name == "" {
+	//	err := core.MissingCapabilityNameError(pc)
+	//	errs = append(errs, *err)
+	//}
+
 	if c.Module == nil {
 		// We can't perform validation if the module isn't loaded
-		return nil
+		return errs
 	}
 	if ic.IsOverrides && c.ModuleSource == "" {
 		// TODO: Add support for validating variables and connections in an overrides file
-		return nil
+		return errs
 	}
 
-	errs := core.ValidateErrors{}
 	// check to make sure the capability module supports the subcategory
 	// examples are "container", "serverless", "static-site", "server"
 	// TODO: Add support for validating app category

--- a/core/capability_identity.go
+++ b/core/capability_identity.go
@@ -29,7 +29,7 @@ func (i CapabilityIdentity) Match(other CapabilityIdentity) bool {
 	if i.Name != "" && other.Name != "" {
 		return i.Name == other.Name
 	}
-	
+
 	if i.ModuleSource != other.ModuleSource {
 		return false
 	}

--- a/core/capability_identity.go
+++ b/core/capability_identity.go
@@ -14,11 +14,22 @@ func (s CapabilityIdentities) Find(match CapabilityIdentity) *CapabilityIdentity
 }
 
 type CapabilityIdentity struct {
-	ModuleSource      string                  `json:"moduleSource"`
+	// Name is unique to the application that holds this capability
+	Name string `json:"name"`
+
+	// ModuleSource
+	// Deprecated
+	ModuleSource string `json:"moduleSource"`
+	// ConnectionTargets
+	// Deprecated
 	ConnectionTargets types.ConnectionTargets `json:"connectionTargets"`
 }
 
 func (i CapabilityIdentity) Match(other CapabilityIdentity) bool {
+	if i.Name != "" && other.Name != "" {
+		return i.Name == other.Name
+	}
+	
 	if i.ModuleSource != other.ModuleSource {
 		return false
 	}

--- a/core/validate_errors.go
+++ b/core/validate_errors.go
@@ -74,6 +74,13 @@ func MismatchedConnectionContractError(pc ObjectPathContext, blockName, connecti
 	}
 }
 
+func MissingCapabilityNameError(pc ObjectPathContext) *ValidateError {
+	return &ValidateError{
+		ObjectPathContext: pc,
+		ErrorMessage:      fmt.Sprintf("Capability requires a name"),
+	}
+}
+
 func EnvVariableKeyStartsWithNumberError(pc ObjectPathContext) ValidateError {
 	return ValidateError{
 		ObjectPathContext: pc,

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/nullstone-io/module v0.2.9
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250214232057-3b4cfa73737b
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250215211440-fe383c7d057d
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/nullstone-io/module v0.2.9
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213231230-4a29b39045f2
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250214232057-3b4cfa73737b
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/nullstone-io/module v0.2.9
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241106144240-76b4d427665e
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213231230-4a29b39045f2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241106144240-76b4d427665e h1:WyWDLkEVnnk62EWKNrpcfye3lLNeeZDGMMu00hCyBrs=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20241106144240-76b4d427665e/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213231230-4a29b39045f2 h1:IF8ae2kcvFP1fZZLniz8/tRpFix+3mXO6lYhIDfDVdk=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213231230-4a29b39045f2/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213231230-4a29b39045f2 h1:IF8ae2kcvFP1fZZLniz8/tRpFix+3mXO6lYhIDfDVdk=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250213231230-4a29b39045f2/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250214232057-3b4cfa73737b h1:DGgHCCNfmlrFlSJMY+Bf/yBtymlD02L2CKg5gUyKuYE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250214232057-3b4cfa73737b/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250214232057-3b4cfa73737b h1:DGgHCCNfmlrFlSJMY+Bf/yBtymlD02L2CKg5gUyKuYE=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250214232057-3b4cfa73737b/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250215211440-fe383c7d057d h1:frIlyGuRJkDWLWMVMQyAIMrzWPmr02qYJsvVp/i8yhc=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250215211440-fe383c7d057d/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/workspace/config_updater.go
+++ b/workspace/config_updater.go
@@ -78,6 +78,7 @@ func (w ConfigUpdater) RemoveEnvVariablesNotIn(envVariables map[string]string) {
 func (w ConfigUpdater) GetCapabilityUpdater(identity core.CapabilityIdentity) core.CapabilityConfigUpdater {
 	for i, cur := range w.Config.Capabilities {
 		found := identity.Match(core.CapabilityIdentity{
+			Name:              cur.Name,
 			ModuleSource:      cur.Source,
 			ConnectionTargets: cur.Connections.Targets(),
 		})
@@ -95,6 +96,7 @@ func (w ConfigUpdater) RemoveCapabilitiesNotIn(identities core.CapabilityIdentit
 	result := make(types.CapabilityConfigs, 0)
 	for _, cur := range w.Config.Capabilities {
 		found := identities.Find(core.CapabilityIdentity{
+			Name:              cur.Name,
 			ModuleSource:      cur.Source,
 			ConnectionTargets: cur.Connections.Targets(),
 		})

--- a/yaml/app_configuration.go
+++ b/yaml/app_configuration.go
@@ -2,16 +2,6 @@ package yaml
 
 import "gopkg.in/nullstone-io/go-api-client.v0/types"
 
-type CapabilityConfigurations []CapabilityConfiguration
-
-type CapabilityConfiguration struct {
-	ModuleSource        string            `yaml:"module,omitempty" json:"module"`
-	ModuleSourceVersion *string           `yaml:"module_version,omitempty" json:"moduleVersion"`
-	Variables           map[string]any    `yaml:"vars,omitempty" json:"vars"`
-	Connections         ConnectionTargets `yaml:"connections,omitempty" json:"connections"`
-	Namespace           *string           `yaml:"namespace,omitempty" json:"namespace"`
-}
-
 type AppConfiguration struct {
 	BlockConfiguration `yaml:",inline" json:",inline"`
 

--- a/yaml/capability_configuration.go
+++ b/yaml/capability_configuration.go
@@ -1,0 +1,78 @@
+package yaml
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ yaml.Unmarshaler = &CapabilityConfigurations{}
+	_ yaml.Marshaler   = &CapabilityConfigurations{}
+)
+
+type CapabilityConfigurations []CapabilityConfiguration
+
+//goland:noinspection GoMixedReceiverTypes
+func (c CapabilityConfigurations) MarshalYAML() (interface{}, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	if c.hasAnyWithNoName() {
+		return []CapabilityConfiguration(c), nil
+	}
+
+	m := map[string]CapabilityConfiguration{}
+	for _, cc := range c {
+		name := cc.Name
+		cc.Name = ""
+		m[name] = cc
+	}
+	return m, nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (c *CapabilityConfigurations) UnmarshalYAML(node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	ccs := make([]CapabilityConfiguration, 0)
+	switch node.Kind {
+	default:
+		return fmt.Errorf("cannot unmarshal YAML %v into CapabilityConfigurations", node.Kind)
+	case yaml.SequenceNode:
+		if err := node.Decode(&ccs); err != nil {
+			return err
+		}
+	case yaml.MappingNode:
+		m := map[string]CapabilityConfiguration{}
+		if err := node.Decode(&m); err != nil {
+			return err
+		}
+		for k, v := range m {
+			v.Name = k
+			ccs = append(ccs, v)
+		}
+	}
+	*c = ccs
+	return nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (c CapabilityConfigurations) hasAnyWithNoName() bool {
+	for _, cc := range c {
+		if cc.Name == "" {
+			return true
+		}
+	}
+	return false
+}
+
+type CapabilityConfiguration struct {
+	Name                string            `yaml:"name,omitempty" json:"name,omitempty"`
+	ModuleSource        string            `yaml:"module,omitempty" json:"module"`
+	ModuleSourceVersion *string           `yaml:"module_version,omitempty" json:"moduleVersion"`
+	Variables           map[string]any    `yaml:"vars,omitempty" json:"vars"`
+	Connections         ConnectionTargets `yaml:"connections,omitempty" json:"connections"`
+	Namespace           *string           `yaml:"namespace,omitempty" json:"namespace"`
+}

--- a/yaml/capability_configuration_test.go
+++ b/yaml/capability_configuration_test.go
@@ -1,0 +1,111 @@
+package yaml
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestCapabilityConfigurations_UnmarshalYAML(t *testing.T) {
+	tests := map[string]struct {
+		content string
+		want    CapabilityConfigurations
+	}{
+		"empty": {
+			content: `~`,
+			want:    nil,
+		},
+		"sequence": {
+			content: `- module: nullstone/jwt-keys`,
+			want: CapabilityConfigurations{
+				{
+					ModuleSource: "nullstone/jwt-keys",
+				},
+			},
+		},
+		"map": {
+			content: `keys:
+  module: nullstone/jwt-keys`,
+			want: CapabilityConfigurations{
+				{
+					Name:         "keys",
+					ModuleSource: "nullstone/jwt-keys",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got CapabilityConfigurations
+			require.NoError(t, yaml.Unmarshal([]byte(test.content), &got), "unexpected error")
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestCapabilityConfigurations_MarshalYAML(t *testing.T) {
+	tests := map[string]struct {
+		caps CapabilityConfigurations
+		want string
+	}{
+		"nil": {
+			caps: nil,
+			want: "null\n",
+		},
+		"map": {
+			caps: CapabilityConfigurations{
+				{
+					Name:         "cap1",
+					ModuleSource: "nullstone/jwt-keys",
+				},
+				{
+					Name:         "cap2",
+					ModuleSource: "nullstone/rails-cookies",
+				},
+			},
+			want: `cap1:
+    module: nullstone/jwt-keys
+cap2:
+    module: nullstone/rails-cookies
+`,
+		},
+		"mixed": {
+			caps: CapabilityConfigurations{
+				{
+					Name:         "cap1",
+					ModuleSource: "nullstone/jwt-keys",
+				},
+				{
+					ModuleSource: "nullstone/rails-cookies",
+				},
+			},
+			want: `- name: cap1
+  module: nullstone/jwt-keys
+- module: nullstone/rails-cookies
+`,
+		},
+		"sequence": {
+			caps: CapabilityConfigurations{
+				{
+					ModuleSource: "nullstone/jwt-keys",
+				},
+				{
+					ModuleSource: "nullstone/rails-cookies",
+				},
+			},
+			want: `- module: nullstone/jwt-keys
+- module: nullstone/rails-cookies
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := yaml.Marshal(test.caps)
+			require.NoError(t, err, "unexpected error")
+			assert.Equal(t, test.want, string(got))
+		})
+	}
+}

--- a/yaml/capability_configuration_test.go
+++ b/yaml/capability_configuration_test.go
@@ -24,6 +24,16 @@ func TestCapabilityConfigurations_UnmarshalYAML(t *testing.T) {
 				},
 			},
 		},
+		"sequence-with-name": {
+			content: `- name: keys
+  module: nullstone/jwt-keys`,
+			want: CapabilityConfigurations{
+				{
+					Name:         "keys",
+					ModuleSource: "nullstone/jwt-keys",
+				},
+			},
+		},
 		"map": {
 			content: `keys:
   module: nullstone/jwt-keys`,


### PR DESCRIPTION
This adds `name` to a capability in IaC files. This also allows capabilities to be defined as a map or array in the IaC file. (Ideally, the user would use the map, but the support for array is kept for backward compatibility.)

The `workspace/ConfigUpdater` was updated to use this new `name` field. When performing changes on capabilities, this new `name` field is used to identify the capability in Nullstone. If the `name` field is empty, the updater will fall back to the legacy method of utilizing the module source and connection targets. (This is for backward compatibility until everybody upgrades)

Legacy usage (still supported, but added `name` field)
```
apps:
  api:
    capabilities:
      - name: keys # added in this PR
        module: nullstone/jwt-keys
```

New, recommended usage
```
apps:
  api:
    capabilities:
      keys:
        module: nullstone/jwt-keys
```