### PR TITLE
Made updates to support adding capabilities via IaC file

### DIFF
--- a/config/block_configuration.go
+++ b/config/block_configuration.go
@@ -159,7 +159,7 @@ func (b *BlockConfiguration) ToBlock(orgName string, stackId int64) types.Block 
 }
 
 func (b *BlockConfiguration) ApplyChangesTo(ic core.IacContext, updater core.WorkspaceConfigUpdater) error {
-	updater.UpdateSchema(b.ModuleSource, b.ModuleVersion)
+	updater.UpdateSchema(b.ModuleSource, b.ModuleConstraint, b.ModuleVersion)
 	for name, vc := range b.Variables {
 		updater.UpdateVariableValue(name, vc.Value)
 	}

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -101,6 +101,11 @@ func (c CapabilityConfigurations) Resolve(ctx context.Context, resolver core.Res
 }
 
 type CapabilityConfiguration struct {
+	// Id refers the Capability Id stored in Nullstone
+	// It is not used in the IaC representation
+	// It is used primarily to identify the capability when generating infrastructure code
+	Id int64 `json:"id"`
+
 	Name             string                   `json:"name"`
 	ModuleSource     string                   `json:"moduleSource"`
 	ModuleConstraint string                   `json:"moduleConstraint"`
@@ -209,7 +214,7 @@ func (c *CapabilityConfiguration) ApplyChangesTo(ic core.IacContext, updater cor
 		c.doUpdateCapability(capUpdater)
 	} else {
 		// Add capability that doesn't exist in the workspace config yet
-		c.doUpdateCapability(updater.AddCapability(c.Name))
+		c.doUpdateCapability(updater.AddCapability(c.Id, c.Name))
 	}
 	return nil
 }

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -222,7 +222,7 @@ func (c *CapabilityConfiguration) doUpdateCapability(capUpdater core.CapabilityC
 	if capUpdater == nil {
 		return
 	}
-	capUpdater.UpdateSchema(c.ModuleSource, c.ModuleVersion)
+	capUpdater.UpdateSchema(c.ModuleSource, c.ModuleConstraint, c.ModuleVersion)
 	capUpdater.UpdateNamespace(c.Namespace)
 	for name, vc := range c.Variables {
 		capUpdater.UpdateVariableValue(name, vc.Value)

--- a/config/capability_configuration.go
+++ b/config/capability_configuration.go
@@ -53,6 +53,7 @@ func (c CapabilityConfigurations) ToCapabilities() []types.Capability {
 	var result []types.Capability
 	for _, cur := range c {
 		capability := types.Capability{
+			IdModel:             types.IdModel{Id: cur.Id},
 			Name:                cur.Name,
 			ModuleSource:        cur.ModuleSource,
 			ModuleSourceVersion: cur.ModuleConstraint,

--- a/config/connection_configuration.go
+++ b/config/connection_configuration.go
@@ -151,6 +151,13 @@ func (c *ConnectionConfiguration) Normalize(ctx context.Context, pc core.ObjectP
 			ErrorMessage:      err.Error(),
 		}
 	}
+	c.DesiredTarget.StackId = ct.StackId
+	c.DesiredTarget.StackName = ct.StackName
+	c.DesiredTarget.BlockId = ct.BlockId
+	c.DesiredTarget.BlockName = ct.BlockName
+	if c.DesiredTarget.EnvId != nil {
+		c.DesiredTarget.EnvName = ct.EnvName
+	}
 	c.EffectiveTarget = ct
 	return nil
 }

--- a/core/change_applier.go
+++ b/core/change_applier.go
@@ -15,6 +15,7 @@ type WorkspaceConfigUpdater interface {
 	AddOrUpdateEnvVariable(name string, value string, sensitive bool)
 	RemoveEnvVariablesNotIn(envVariables map[string]string)
 	GetCapabilityUpdater(identity CapabilityIdentity) CapabilityConfigUpdater
+	AddCapability(name string) CapabilityConfigUpdater
 	RemoveCapabilitiesNotIn(identities CapabilityIdentities)
 }
 

--- a/core/change_applier.go
+++ b/core/change_applier.go
@@ -15,7 +15,7 @@ type WorkspaceConfigUpdater interface {
 	AddOrUpdateEnvVariable(name string, value string, sensitive bool)
 	RemoveEnvVariablesNotIn(envVariables map[string]string)
 	GetCapabilityUpdater(identity CapabilityIdentity) CapabilityConfigUpdater
-	AddCapability(name string) CapabilityConfigUpdater
+	AddCapability(id int64, name string) CapabilityConfigUpdater
 	RemoveCapabilitiesNotIn(identities CapabilityIdentities)
 }
 

--- a/core/change_applier.go
+++ b/core/change_applier.go
@@ -9,7 +9,7 @@ type ChangeApplier interface {
 }
 
 type WorkspaceConfigUpdater interface {
-	UpdateSchema(moduleSource string, moduleVersion *types.ModuleVersion)
+	UpdateSchema(moduleSource, moduleConstraint string, moduleVersion *types.ModuleVersion)
 	UpdateVariableValue(name string, value any)
 	UpdateConnectionTarget(name string, desired, effective types.ConnectionTarget)
 	AddOrUpdateEnvVariable(name string, value string, sensitive bool)
@@ -20,7 +20,7 @@ type WorkspaceConfigUpdater interface {
 }
 
 type CapabilityConfigUpdater interface {
-	UpdateSchema(moduleSource string, moduleVersion *types.ModuleVersion)
+	UpdateSchema(moduleSource, moduleConstraint string, moduleVersion *types.ModuleVersion)
 	UpdateVariableValue(name string, value any)
 	UpdateConnectionTarget(name string, desired, effective types.ConnectionTarget)
 	UpdateNamespace(namespace *string)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/nullstone-io/module v0.2.9
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250225172210-6c6bec666cde
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250226001729-ed8c925d2909
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/nullstone-io/module v0.2.9
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250224142749-646847043898
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250225172210-6c6bec666cde
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/nullstone-io/module v0.2.9
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250220015615-a8d2be4e17c0
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250224142749-646847043898
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250224142749-646847043898 h1:beBet5xpR+R3tK7197dh3Dpe/Zp1RSgHa+3se5aBLrU=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250224142749-646847043898/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250225172210-6c6bec666cde h1:MEvFo0TQPd3Xbpk5wk0nESdKKesJFyD6ceRWKotVNY4=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250225172210-6c6bec666cde/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250225172210-6c6bec666cde h1:MEvFo0TQPd3Xbpk5wk0nESdKKesJFyD6ceRWKotVNY4=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250225172210-6c6bec666cde/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250226001729-ed8c925d2909 h1:sA7uXNn5VkukuylQwExmfprv4iMdIBckg7rNgNl5Lk0=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250226001729-ed8c925d2909/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250220015615-a8d2be4e17c0 h1:Rqv7FHPr0a/F2fgGp+SdGkwAMr+lMIQovSDM0myKvF4=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250220015615-a8d2be4e17c0/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250224142749-646847043898 h1:beBet5xpR+R3tK7197dh3Dpe/Zp1RSgHa+3se5aBLrU=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20250224142749-646847043898/go.mod h1:m/JNiW4XSXjRLAedd7LYOO0l/FfCiKffRFolkKpfpgA=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/workspace/config_updater.go
+++ b/workspace/config_updater.go
@@ -97,6 +97,15 @@ func (w ConfigUpdater) GetCapabilityUpdater(identity core.CapabilityIdentity) co
 	return nil
 }
 
+func (w ConfigUpdater) AddCapability(name string) core.CapabilityConfigUpdater {
+	w.Config.Capabilities = append(w.Config.Capabilities, types.CapabilityConfig{Name: name})
+	ccu := CapabilityConfigUpdater{
+		WorkspaceConfig: w.Config,
+		Index:           len(w.Config.Capabilities) - 1,
+	}
+	return ccu
+}
+
 func (w ConfigUpdater) RemoveCapabilitiesNotIn(identities core.CapabilityIdentities) {
 	result := make(types.CapabilityConfigs, 0)
 	for _, cur := range w.Config.Capabilities {
@@ -106,6 +115,7 @@ func (w ConfigUpdater) RemoveCapabilitiesNotIn(identities core.CapabilityIdentit
 			ConnectionTargets: cur.Connections.EffectiveTargets(),
 		})
 		if found != nil {
+			// If we found the capability in the IaC file, let's keep it
 			result = append(result, cur)
 		}
 	}

--- a/workspace/config_updater.go
+++ b/workspace/config_updater.go
@@ -9,18 +9,24 @@ import (
 var (
 	_ core.WorkspaceConfigUpdater  = ConfigUpdater{}
 	_ core.CapabilityConfigUpdater = CapabilityConfigUpdater{}
+
+	DefaultModuleConstraint = "latest"
 )
 
 type ConfigUpdater struct {
 	Config *types.WorkspaceConfig
 }
 
-func (w ConfigUpdater) UpdateSchema(moduleSource string, moduleVersion *types.ModuleVersion) {
+func (w ConfigUpdater) UpdateSchema(moduleSource, moduleConstraint string, moduleVersion *types.ModuleVersion) {
 	if moduleVersion == nil {
 		return
 	}
 	if moduleSource != "" {
 		w.Config.Source = moduleSource
+	}
+	w.Config.SourceConstraint = DefaultModuleConstraint
+	if moduleConstraint != "" {
+		w.Config.SourceConstraint = moduleConstraint
 	}
 	w.Config.SourceVersion = moduleVersion.Version
 	if w.Config.Variables == nil {
@@ -133,13 +139,17 @@ type CapabilityConfigUpdater struct {
 	Index           int
 }
 
-func (c CapabilityConfigUpdater) UpdateSchema(moduleSource string, moduleVersion *types.ModuleVersion) {
+func (c CapabilityConfigUpdater) UpdateSchema(moduleSource, moduleConstraint string, moduleVersion *types.ModuleVersion) {
 	c.doOperation(func(cc *types.CapabilityConfig) {
 		if moduleVersion == nil {
 			return
 		}
 		if moduleSource != "" {
 			cc.Source = moduleSource
+		}
+		cc.SourceConstraint = DefaultModuleConstraint
+		if moduleConstraint != "" {
+			cc.SourceConstraint = moduleConstraint
 		}
 		cc.SourceVersion = moduleVersion.Version
 		if cc.Variables == nil {

--- a/workspace/config_updater.go
+++ b/workspace/config_updater.go
@@ -23,6 +23,12 @@ func (w ConfigUpdater) UpdateSchema(moduleSource string, moduleVersion *types.Mo
 		w.Config.Source = moduleSource
 	}
 	w.Config.SourceVersion = moduleVersion.Version
+	if w.Config.Variables == nil {
+		w.Config.Variables = types.Variables{}
+	}
+	if w.Config.Connections == nil {
+		w.Config.Connections = types.Connections{}
+	}
 	ModuleSchema(moduleVersion.Manifest).UpdateSchema(w.Config.Variables, w.Config.Connections)
 }
 
@@ -136,6 +142,12 @@ func (c CapabilityConfigUpdater) UpdateSchema(moduleSource string, moduleVersion
 			cc.Source = moduleSource
 		}
 		cc.SourceVersion = moduleVersion.Version
+		if cc.Variables == nil {
+			cc.Variables = types.Variables{}
+		}
+		if cc.Connections == nil {
+			cc.Connections = types.Connections{}
+		}
 		ModuleSchema(moduleVersion.Manifest).UpdateSchema(cc.Variables, cc.Connections)
 	})
 }

--- a/workspace/config_updater.go
+++ b/workspace/config_updater.go
@@ -109,8 +109,8 @@ func (w ConfigUpdater) GetCapabilityUpdater(identity core.CapabilityIdentity) co
 	return nil
 }
 
-func (w ConfigUpdater) AddCapability(name string) core.CapabilityConfigUpdater {
-	w.Config.Capabilities = append(w.Config.Capabilities, types.CapabilityConfig{Name: name})
+func (w ConfigUpdater) AddCapability(id int64, name string) core.CapabilityConfigUpdater {
+	w.Config.Capabilities = append(w.Config.Capabilities, types.CapabilityConfig{Id: id, Name: name})
 	ccu := CapabilityConfigUpdater{
 		WorkspaceConfig: w.Config,
 		Index:           len(w.Config.Capabilities) - 1,


### PR DESCRIPTION
This makes several updates to support capability management via IaC file:
- Normalize updates Connection.DesiredTarget with name fields and Id fields if missing/necessary
- The updater for capabilities was improved to support adding new capabilities
- The updater for block and capability was improved to set `WorkspaceConfig.SourceConstraint` from iac `module_version` yaml value
- Variables/Connections were set to non-nil to prevent panics in updater

Additionally, go-api-client was updated (https://github.com/nullstone-io/go-api-client/pull/112)